### PR TITLE
Add action_mailer.default_url_options to production.rb

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -56,10 +56,15 @@ test:
 #   database: soccerpub_production
 #   username: soccerpub
 #   password: <%= ENV['SOCCERPUB_DATABASE_PASSWORD'] %>
+
 production:
   <<: *default
   database: <%= ENV['DB_NAME'] %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   host: <%= ENV['DB_HOSTNAME'] %>
+
+# production:
+#   <<: *default
+#   database: soccerpub_production
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,16 +66,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :sendgrid
-  # host = 'soccerpub-88.herokuapp.com'
-  # config.action_mailer.default_url_options = { host: host }
-  # ActionMailer::Base.smtp_settings = {
-  #   port: ENV['MAILGUN_SMTP_PORT'],
-  #   address: ENV['MAILGUN_SMTP_SERVER'],
-  #   user_name: ENV['MAILGUN_SMTP_LOGIN'],
-  #   password: ENV['MAILGUN_SMTP_PASSWORD'],
-  #   domain: host,
-  #   authentication: :plain
-  # }
+  host = 'www.soccerpub-app.work'
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
本番環境用の設定ファイル、config/production.rbにaction_mailer.default_url_optionsを追加し、sendgridでのエラーに対応しました。