### PR TITLE
Add charset to database.yml production

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -459,5 +459,4 @@
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-# Layout/LineLength:
-#   Max: 166
+

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,8 +15,8 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   # docker configure
-  password: password
-  host: db
+  # password: password
+  # host: db
 
 development:
   <<: *default
@@ -63,6 +63,7 @@ production:
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   host: <%= ENV['DB_HOSTNAME'] %>
+  charset: utf8
 
 # production:
 #   <<: *default


### PR DESCRIPTION
本番環境のデータベースの文字コードをutf8に変更するため、database.ymlにcharset: utf8を追加しました。